### PR TITLE
cli socket path bug fix

### DIFF
--- a/apps/OpenBTS-UMTS.cpp
+++ b/apps/OpenBTS-UMTS.cpp
@@ -260,7 +260,8 @@ int main(int argc, char *argv[])
 
 	struct sockaddr_un cmdSockName;
 	cmdSockName.sun_family = AF_UNIX;
-	const char* sockpath = gConfig.getStr("CLI.SocketPath").c_str();
+	string s_sockpath = gConfig.getStr("CLI.SocketPath");
+	const char* sockpath = s_sockpath.c_str();
 	char rmcmd[strlen(sockpath)+5];
 	sprintf(rmcmd,"rm -f %s",sockpath);
 	if (system(rmcmd)) {}	// The 'if' shuts up gcc warnings.


### PR DESCRIPTION
## Bug in the CLI socket
The `OpenBTS-UMTSCLI` app is unable to locate the socket used for sending commands to `OpenBTS-UMTS` app
## Steps to Reproduce the Bug

1. **Run the OpenBTS-UMTS Application:**
   - Launch the OpenBTS-UMTS application by running: `./OpenBTS-UMTS`.

2. **Run the OpenBTS-UMTSCLI Application:**
   - Launch the OpenBTS-UMTS application by running: `./OpenBTS-UMTSCLI`.

3. **Send command from the CLI app:**
   - In the `OpenBTS-UMTSCLI` app run a command _e.g_ `rawconfig`.

4. **Expected Behavior:**
   - The command is expected to be sent to the `OpenBTS-UMTS` application, and the corresponding response should be displayed.

5. **Actual Behavior:**
   - Instead, the output is:
   ```
    sending datagram: No such file or directory
    Is the remote application running?
   ```

## Root Cause
The reason for this problem is the way of saving the path string of the CLI socket.
 In `apps/OpenBTS-UMTS.cpp` line 263:
 ```cpp
const char* sockpath = gConfig.getStr("CLI.SocketPath").c_str();
```
The `c_str` function returns a pointer that points to the internal array currently used by the `string` object. However, as we are only using a pointer to the object without retaining the `string` object itself, the pointer refers to an array containing garbage values instead of the correct path (which is `/var/run/OpenBTS-UMTS-command` by default). Consequently, rather than opening the socket in the intended path, the code attempts to open the socket file with a nonsensical name in the current directory.

## Fix
To address this bug, I introduced a new variable to hold the `string` object, and then added another variable of type `char*` to reference the array within the string object. With these changes, the socket now opens correctly in the expected path, allowing the successful transmission of commands from `OpenBTS-UMTSCLI` app.